### PR TITLE
ignore thumbnail and fix encoding

### DIFF
--- a/backend-php/config.php
+++ b/backend-php/config.php
@@ -8,7 +8,7 @@ $config = [
 	SERVE_URL => "https://YOUR_EMAIL_IMAGE_SERVER_URL/",
 
 	/* Base Url for accessing Mosaco */
-	BASE_URL => "http://YOUR_MOSAICO_URL",
+	BASE_URL => "http://YOUR_MOSAICO_URL/",
 	
 	/* local file system base path to where image directories are located */
 	BASE_DIR => "/var/www/mosaico/",

--- a/backend-php/index.php
+++ b/backend-php/index.php
@@ -14,7 +14,7 @@ const STATIC_DIR = 7;
 const THUMBNAILS_URL = 8;
 const THUMBNAILS_DIR = 9;
 const THUMBNAIL_WIDTH = 10;
-const THUMBNAIL_HEIGHT = 111;
+const THUMBNAIL_HEIGHT = 11;
 
 require "config.php";
 
@@ -347,7 +347,7 @@ function ProcessDlRequest()
 			$headers = array();
 
 			$headers[] = "MIME-Version: 1.0";
-			$headers[] = "Content-type: text/html; charset=iso-8859-1";
+			$headers[] = "Content-type: text/html; charset=utf-8";
 			$headers[] = "To: $to";
 			$headers[] = "Subject: $subject";
 

--- a/upload/.htaccess
+++ b/upload/.htaccess
@@ -1,2 +1,3 @@
 RewriteEngine On
+RewriteCond %{REQUEST_URI} !^/upload/thumbnail
 RewriteRule ^(.*)$ /backend-php/index.php [QSA,L]


### PR DESCRIPTION
With the actual mail encoding german umlaute are not correct. And in mosaico/image gallery the thumbnails are not  shown. This merge will fix it.

When you are interested I can also implement a ftp upload for the images.